### PR TITLE
Adding Verify method

### DIFF
--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -391,6 +391,17 @@ namespace Moq.AutoMock.Tests
             }
 
             [Fact]
+            public void You_can_verify_all_setups_marked_as_verifiable()
+            {
+                mocker.Setup<IService1>(x => x.Void()).Verifiable();
+                mocker.Setup<IService5>(x => x.Name).Returns("Test");
+
+                mocker.Get<IService1>().Void();
+                
+                mocker.Verify();
+            }
+
+            [Fact]
             public void If_you_verify_a_method_that_returns_a_value_type_without_specifying_return_type_you_get_useful_exception()
             {
                 //a method without parameters

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -214,6 +214,18 @@ namespace Moq.AutoMock
         }
 
         /// <summary>
+        /// This is a shortcut for calling `mock.Verify()` on every mock that we have.
+        /// </summary>
+        public void Verify()
+        {
+            foreach (var pair in typeMap)
+            {
+                if (pair.Value.IsMock)
+                    (((MockInstance)pair.Value).Mock).Verify();
+            }
+        }
+
+        /// <summary>
         /// Shortcut for mock.Setup(...), creating the mock when necessary.
         /// </summary>
         public ISetup<TService, object> Setup<TService>(Expression<Func<TService, object>> setup)


### PR DESCRIPTION
Mock have both a Verify and VerifyAll method but currently AutoMocker is only exposing a helper method for VerifyAll. 
This exposes a helper Verify method to be able to call Verify on all mocks. Very similar to the existing VerifyAll method. This allows for verifying only setups marked as verifiable.
